### PR TITLE
Add partner tracking and push-to-talk support

### DIFF
--- a/Client.gd
+++ b/Client.gd
@@ -7,6 +7,7 @@ var server_ip = "192.168.1.170"
 var peer = ENetMultiplayerPeer.new()
 @export var playerScene : PackedScene
 var serverIsReady : bool
+var partner_id : int = 0
 
 @export var gameSpawnLocation : NodePath
 # Called when the node enters the scene tree for the first time.
@@ -26,23 +27,31 @@ func _process(delta):
 
 func peerConnected(id):
 
-	print("peer connected! " + str(id))
-	#var p = playerScene.instantiate()
-	#add_child(p)
-	#p.name = str(id)
-	#p.get_node("AudioManager").setupAudio(id)
+        print("peer connected! " + str(id))
+        if id != multiplayer.get_unique_id():
+                partner_id = id
+                AudioManager.set_partner_id(partner_id)
+        #var p = playerScene.instantiate()
+        #add_child(p)
+        #p.name = str(id)
+        #p.get_node("AudioManager").setupAudio(id)
 
 func peerDisconnected(id):
-	print("peer disconnected! " + str(id))
+        print("peer disconnected! " + str(id))
+        if id == partner_id:
+                partner_id = 0
+                AudioManager.clear_partner_id()
 
 func _on_connect_to_server_pressed():
-	var error = peer.create_client(server_ip, 8910)
-	if error:
-		print("we have an error for client: " + error)
-	multiplayer.multiplayer_peer = peer
-	$"../Status".text = "You are connected to the app, id = " + str(multiplayer.get_unique_id())
-	
-	AudioManager.setupAudio(multiplayer.get_unique_id())
+        var error = peer.create_client(server_ip, 8910)
+        if error:
+                print("we have an error for client: " + error)
+        multiplayer.multiplayer_peer = peer
+        $"../Status".text = "You are connected to the app, id = " + str(multiplayer.get_unique_id())
+
+        partner_id = 0
+        AudioManager.clear_partner_id()
+        AudioManager.setupAudio(multiplayer.get_unique_id())
 
 	#var p = playerScene.instantiate()
 	#get_node(gameSpawnLocation).add_child(p)

--- a/Server.gd
+++ b/Server.gd
@@ -3,6 +3,7 @@ extends Node
 var peer = ENetMultiplayerPeer.new()
 @export var playerScene : PackedScene
 var serverIsReady : bool
+var partner_id : int = 0
 
 @export var gameSpawnLocation : NodePath
 # Called when the node enters the scene tree for the first time.
@@ -24,16 +25,23 @@ func _process(delta):
 
 func peerConnected(id):
 
-	print("peer connected! " + str(id))
+        print("peer connected! " + str(id))
+        partner_id = id
+        AudioManager.set_partner_id(partner_id)
 
 func peerDisconnected(id):
-	print("peer disconnected! " + str(id))
+        print("peer disconnected! " + str(id))
+        if id == partner_id:
+                partner_id = 0
+                AudioManager.clear_partner_id()
 
 func _on_host_button_down():
-	var error = peer.create_server(8910)
-	if error:
-		print("we have an error for server: " + error)
-	multiplayer.multiplayer_peer = peer
-	$"../Status".text = "You are hosting the app, id = " + str(multiplayer.get_unique_id())
-	
-	AudioManager.setupAudio(1)
+        var error = peer.create_server(8910)
+        if error:
+                print("we have an error for server: " + error)
+        multiplayer.multiplayer_peer = peer
+        $"../Status".text = "You are hosting the app, id = " + str(multiplayer.get_unique_id())
+
+        partner_id = 0
+        AudioManager.clear_partner_id()
+        AudioManager.setupAudio(1)

--- a/TalkButton.gd
+++ b/TalkButton.gd
@@ -1,0 +1,14 @@
+extends Button
+
+func _ready():
+        _update_text(AudioManager.is_talk_mode())
+
+func _pressed():
+        var is_talking = AudioManager.toggle_talk_mode()
+        _update_text(is_talking)
+
+func _update_text(is_talking: bool):
+        if is_talking:
+                text = "Talking"
+        else:
+                text = "Talk"

--- a/TalkButton.gd.uid
+++ b/TalkButton.gd.uid
@@ -1,0 +1,1 @@
+uid://csb8jvunhkf1w

--- a/audio_manager.gd
+++ b/audio_manager.gd
@@ -1,11 +1,15 @@
 extends Node
 
-#@onready var input : AudioStreamPlayer 
+#@onready var input : AudioStreamPlayer
 var input : AudioStreamPlayer
 var output : AudioStreamPlayer2D
 var index : int
 var effect : AudioEffectCapture
 var playback
+# Identifier for the remote peer we are communicating with.
+var partner_id : int = 0
+# Push-to-talk mode flag.
+var talk_mode := false
 #@export var outputPath : NodePath
 var inputThreshold = 0.005
 var receiveBuffer := PackedFloat32Array()
@@ -14,72 +18,98 @@ var audioIsReady = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+        pass # Replace with function body.
 
 func setupAudio(id):
-	#input = $Input
-	input = AudioStreamPlayer.new()
-	set_multiplayer_authority(id)
-	if is_multiplayer_authority():
-		input.stream = AudioStreamMicrophone.new()
-		input.name = "NewInput"
-		input.bus = "Record"
-		input.autoplay = true
-		input.play()
-		index = AudioServer.get_bus_index("Record")
-		effect = AudioServer.get_bus_effect(index, 0)
-		add_child(input)
-		
-		output = AudioStreamPlayer2D.new()
-		output.stream = AudioStreamGenerator.new()
-		output.stream.mix_rate = 48000
-		output.bus = "Master"
-		output.autoplay = true
-		add_child(output)
-		output.play()
-		playback = output.get_stream_playback()
-	
-	#print(outputPath)
-	#playback = get_node(outputPath).get_stream_playback()
-	audioIsReady = true
-	print("chilling")
+        #input = $Input
+        input = AudioStreamPlayer.new()
+        set_multiplayer_authority(id)
+        if is_multiplayer_authority():
+                input.stream = AudioStreamMicrophone.new()
+                input.name = "NewInput"
+                input.bus = "Record"
+                input.autoplay = true
+                input.play()
+                index = AudioServer.get_bus_index("Record")
+                effect = AudioServer.get_bus_effect(index, 0)
+                add_child(input)
+
+                output = AudioStreamPlayer2D.new()
+                output.stream = AudioStreamGenerator.new()
+                output.stream.mix_rate = 48000
+                output.bus = "Master"
+                output.autoplay = true
+                add_child(output)
+                output.play()
+                playback = output.get_stream_playback()
+
+        #print(outputPath)
+        #playback = get_node(outputPath).get_stream_playback()
+        audioIsReady = true
+        print("chilling")
+
+# Store the id of the remote peer that audio should be sent to.
+func set_partner_id(id: int):
+        partner_id = id
+
+# Clear the stored remote peer id.
+func clear_partner_id():
+        partner_id = 0
+
+# Toggle push-to-talk mode and return the new state.
+func toggle_talk_mode() -> bool:
+        talk_mode = !talk_mode
+        return talk_mode
+
+# Retrieve the current push-to-talk state.
+func is_talk_mode() -> bool:
+        return talk_mode
+
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	if !audioIsReady: return
-	
-	if is_multiplayer_authority():
-		processMic()
-	processVoice()
-	pass
+        if !audioIsReady:
+                return
+
+        if is_multiplayer_authority():
+                processMic()
+        processVoice()
+        pass
 
 func processMic():
-	var sterioData : PackedVector2Array = effect.get_buffer(effect.get_frames_available())
-	
-	if sterioData.size() > 0:
-		
-		var data = PackedFloat32Array()
-		data.resize(sterioData.size())
-		var maxAmplitude := 0.0
-		
-		for i in range(sterioData.size()):
-			var value = (sterioData[i].x + sterioData[i].y) / 2
-			maxAmplitude = max(value, maxAmplitude)
-			data[i] = value
-		if maxAmplitude < inputThreshold:
-			return
-		#print("sending data from " + str(multiplayer.get_unique_id()))
-		sendData.rpc(data)
-		#sendData(data)
-		
+        if effect == null:
+                return
+        var frames_available := effect.get_frames_available()
+        if frames_available <= 0:
+                return
+        var sterioData : PackedVector2Array = effect.get_buffer(frames_available)
+        if !talk_mode or partner_id == 0:
+                return
+
+        if sterioData.size() > 0:
+
+                var data = PackedFloat32Array()
+                data.resize(sterioData.size())
+                var maxAmplitude := 0.0
+
+                for i in range(sterioData.size()):
+                        var value = (sterioData[i].x + sterioData[i].y) / 2
+                        maxAmplitude = max(value, maxAmplitude)
+                        data[i] = value
+                if maxAmplitude < inputThreshold:
+                        return
+                #print("sending data from " + str(multiplayer.get_unique_id()))
+                sendData.rpc_id(partner_id, data)
+                #sendData(data)
+
 
 func processVoice():
-	if receiveBuffer.size() <= 0:
-		return
-	#print("getting data addressed to " + str(multiplayer.get_unique_id()))
-	for i in range(min(playback.get_frames_available(), receiveBuffer.size())):
-		playback.push_frame(Vector2(receiveBuffer[0], receiveBuffer[0]))
-		receiveBuffer.remove_at(0)
+        if receiveBuffer.size() <= 0:
+                return
+        #print("getting data addressed to " + str(multiplayer.get_unique_id()))
+        for i in range(min(playback.get_frames_available(), receiveBuffer.size())):
+                playback.push_frame(Vector2(receiveBuffer[0], receiveBuffer[0]))
+                receiveBuffer.remove_at(0)
 
 @rpc("any_peer", "call_remote", "unreliable_ordered")
 func sendData(data : PackedFloat32Array):
-	receiveBuffer.append_array(data)
+        receiveBuffer.append_array(data)

--- a/testScene.tscn
+++ b/testScene.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://ca04c1wx0kvdo"]
+[gd_scene load_steps=5 format=3 uid="uid://ca04c1wx0kvdo"]
 
 [ext_resource type="Script" uid="uid://dq4oh0m2yug2r" path="res://Server.gd" id="1_lyn0j"]
 [ext_resource type="Script" uid="uid://bejcfb0tass5v" path="res://Client.gd" id="2_j5xaw"]
 [ext_resource type="PackedScene" uid="uid://dwjn1gvyut2nn" path="res://character.tscn" id="2_o1nn7"]
+[ext_resource type="Script" uid="uid://csb8jvunhkf1w" path="res://TalkButton.gd" id="3_9l7cv"]
 
 [node name="Node2D" type="Node2D"]
 
@@ -37,6 +38,14 @@ offset_right = 1141.0
 offset_bottom = 23.0
 text = "Status"
 horizontal_alignment = 1
+
+[node name="TalkButton" type="Button" parent="."]
+offset_left = 504.0
+offset_top = 50.0
+offset_right = 592.0
+offset_bottom = 95.0
+text = "Talk"
+script = ExtResource("3_9l7cv")
 
 [connection signal="button_down" from="Server/Host" to="Server" method="_on_host_button_down"]
 [connection signal="pressed" from="Client/ConnectToServer" to="Client" method="_on_connect_to_server_pressed"]


### PR DESCRIPTION
## Summary
- track partner peer ids on both client and server scripts to target audio streams
- add a push-to-talk mode in the audio manager and use rpc_id to send audio only to the paired peer
- introduce a UI talk button and script that toggles talk mode and updates its label

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c96c89f4148331969441920a2814e4