### PR TITLE
Fix Opus playback rate and add diagnostics

### DIFF
--- a/audio_manager.gd
+++ b/audio_manager.gd
@@ -12,6 +12,9 @@ var talk_mode := false
 #@export var outputPath : NodePath
 var receiveBuffer : Array[PackedByteArray] = []
 var audioIsReady = false
+# Debug counters used to limit how many diagnostic lines we print.
+var _mic_debug_count := 0
+var _playback_debug_count := 0
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -20,7 +23,7 @@ func _ready():
 	pass # Replace with function body.
 
 func setupAudio(id):
-	
+
 	input = AudioStreamPlayer.new()
 	set_multiplayer_authority(id)
 	if is_multiplayer_authority():
@@ -35,8 +38,10 @@ func setupAudio(id):
 			AudioServer.set_bus_mute(index, true)
 			input.bus = microphone_bus_name
 			effect = _get_opus_effect_for_bus(index)
-			if effect == null:
-				push_error("AudioEffectOpusChunked not found on bus '%s'." % microphone_bus_name)
+					if effect == null:
+						push_error("AudioEffectOpusChunked not found on bus '%s'." % microphone_bus_name)
+					else:
+						_print_effect_diagnostics(microphone_bus_name)
 		else:
 			push_error("Unable to find a microphone bus. Configure 'MicrophoneBus' with an AudioEffectOpusChunked effect.")
 		input.autoplay = true
@@ -45,6 +50,7 @@ func setupAudio(id):
 
 		output = AudioStreamPlayer.new()
 		playback_stream = AudioStreamOpusChunked.new()
+		_configure_playback_stream()
 		output.stream = playback_stream
 		output.bus = "Master"
 		output.autoplay = true
@@ -53,6 +59,57 @@ func setupAudio(id):
 
 	audioIsReady = true
 	print("chilling")
+
+func _print_effect_diagnostics(bus_name: String) -> void:
+	if effect == null:
+		return
+
+	var audio_mix_rate := AudioServer.get_mix_rate()
+	var effect_mix_rate : Variant = "unknown"
+	if effect.has_method("get_mix_rate"):
+		effect_mix_rate = effect.get_mix_rate()
+
+	var effect_channels : Variant = "unknown"
+	if effect.has_method("get_channels"):
+		effect_channels = effect.get_channels()
+
+	print("Opus capture effect configured on bus '%s'. AudioServer mix rate=%s, effect mix rate=%s, channels=%s" % [bus_name, audio_mix_rate, effect_mix_rate, effect_channels])
+	if effect_mix_rate == "unknown" or effect_channels == "unknown":
+		print("Effect available properties:", _collect_property_names(effect))
+
+func _configure_playback_stream() -> void:
+	if playback_stream == null:
+		return
+
+	var target_mix_rate := AudioServer.get_mix_rate()
+	var before_mix_rate : Variant = "unavailable"
+	if playback_stream.has_method("get_mix_rate"):
+		before_mix_rate = playback_stream.get_mix_rate()
+
+	var property_names := _collect_property_names(playback_stream)
+	if playback_stream.has_method("set_mix_rate"):
+		playback_stream.set_mix_rate(target_mix_rate)
+	else:
+		print("AudioStreamOpusChunked is missing set_mix_rate(). Properties:", property_names)
+
+	var after_mix_rate : Variant = before_mix_rate
+	if playback_stream.has_method("get_mix_rate"):
+		after_mix_rate = playback_stream.get_mix_rate()
+	else:
+		after_mix_rate = target_mix_rate
+
+	print("Configured playback stream mix rate. target=%s, before=%s, after=%s" % [target_mix_rate, before_mix_rate, after_mix_rate])
+	if playback_stream.has_method("get_channels"):
+		print("Playback stream channels:", playback_stream.get_channels())
+	else:
+		print("Playback stream property list:", property_names)
+
+func _collect_property_names(obj: Object) -> Array:
+	var names : Array = []
+	for property in obj.get_property_list():
+		if property.has("name"):
+			names.append(property["name"])
+	return names
 
 func _get_opus_effect_for_bus(bus_index: int) -> AudioEffectOpusChunked:
 	if bus_index == -1:
@@ -98,13 +155,20 @@ func _process(delta):
 	processVoice()
 
 func processVoice():
-	if playback_stream == null or receiveBuffer.size() <= 0:
-		return
+        if playback_stream == null or receiveBuffer.size() <= 0:
+                return
 
-	while playback_stream.chunk_space_available() and receiveBuffer.size() > 0:
-		var packet : PackedByteArray = receiveBuffer[0]
-		receiveBuffer.remove_at(0)
-		playback_stream.push_opus_packet(packet, 0, 0)
+        while playback_stream.chunk_space_available() and receiveBuffer.size() > 0:
+                var packet : PackedByteArray = receiveBuffer[0]
+                receiveBuffer.remove_at(0)
+                playback_stream.push_opus_packet(packet, 0, 0)
+
+                if _playback_debug_count < 5:
+                        var playback_mix_rate : Variant = "unknown"
+                        if playback_stream.has_method("get_mix_rate"):
+                                playback_mix_rate = playback_stream.get_mix_rate()
+                        print("Playback chunk #%s pushed: size=%s bytes, queued packets remaining=%s, playback mix rate=%s" % [_playback_debug_count + 1, packet.size(), receiveBuffer.size(), playback_mix_rate])
+                        _playback_debug_count += 1
 
 @rpc("any_peer", "call_remote", "unreliable_ordered")
 func sendData(data : PackedByteArray):
@@ -114,9 +178,18 @@ func processMic():
 	if effect == null or !is_multiplayer_authority():
 		return
 
-	var prepend := PackedByteArray()
-	while effect.chunk_available():
-		var opusdata : PackedByteArray = effect.read_opus_packet(prepend)
-		effect.drop_chunk()
-		if talk_mode and partner_id != 0 and opusdata.size() > 0:
-			sendData.rpc_id(partner_id, opusdata)
+        var prepend := PackedByteArray()
+        while effect.chunk_available():
+                var opusdata : PackedByteArray = effect.read_opus_packet(prepend)
+                effect.drop_chunk()
+                var should_send := talk_mode and partner_id != 0 and opusdata.size() > 0
+
+                if _mic_debug_count < 5:
+                        var effect_mix_rate : Variant = "unknown"
+                        if effect.has_method("get_mix_rate"):
+                                effect_mix_rate = effect.get_mix_rate()
+                        print("Mic chunk #%s: size=%s bytes, should_send=%s, talk_mode=%s, partner_id=%s, effect mix rate=%s" % [_mic_debug_count + 1, opusdata.size(), should_send, talk_mode, partner_id, effect_mix_rate])
+                        _mic_debug_count += 1
+
+                if should_send:
+                        sendData.rpc_id(partner_id, opusdata)


### PR DESCRIPTION
## Summary
- align the AudioStreamOpusChunked playback mix rate with the active audio server rate
- add helper diagnostics for Opus capture and playback setup
- emit limited packet-level logging to trace recording and playback behaviour

## Testing
- not run (Godot client unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd727774708331a3495f95ddb91725