### PR TITLE
Fix local audio streaming setup

### DIFF
--- a/Client.gd
+++ b/Client.gd
@@ -8,45 +8,46 @@ var server_port = 4242  # Use the same port for both local and remote for consis
 var peer = ENetMultiplayerPeer.new()
 var serverIsReady : bool
 var partner_id : int = 0
+var _connecting_to_local := false
+var _audio_initialized := false
 
 func _ready():
-	multiplayer.peer_connected.connect(peerConnected)
-	multiplayer.peer_disconnected.connect(peerDisconnected)
+        multiplayer.peer_connected.connect(peerConnected)
+        multiplayer.peer_disconnected.connect(peerDisconnected)
+        multiplayer.connected_to_server.connect(_on_connected_to_server)
+        multiplayer.connection_failed.connect(_on_connection_failed)
+        multiplayer.server_disconnected.connect(_on_server_disconnected)
 
 func connect_client_to_server():
-	var args = OS.get_cmdline_args()
-	var use_local = "--local" in args
-	var server_ip
-	if use_local:
-		server_ip = server_ip_local
-	else:
-		server_ip = server_ip_remote
-		
-	var conn_type
-	if use_local:
-		conn_type = "local"
-	else:
-		conn_type = "remote"
-	
-	peer = ENetMultiplayerPeer.new()
-	var error = peer.create_client(server_ip, server_port)
-	if error == OK:
-		multiplayer.multiplayer_peer = peer
-		showStatus("Attempting connection to %s server at %s:%d..." % [conn_type, server_ip, server_port])
-	else:
-		showStatus("Failed to create client peer: %s" % error)
+        var args = OS.get_cmdline_args()
+        _connecting_to_local = "--local" in args
+        var server_ip
+        if _connecting_to_local:
+                server_ip = server_ip_local
+        else:
+                server_ip = server_ip_remote
 
-	if use_local:
-		# Do things specific to local networking
-		showStatus("You're connected to the local app, id = " + str(multiplayer.get_unique_id()))
-		partner_id = 0
-		AudioManager.clear_partner_id()
-		AudioManager.setupAudio(multiplayer.get_unique_id())
+        var conn_type
+        if _connecting_to_local:
+                conn_type = "local"
+        else:
+                conn_type = "remote"
+
+        peer = ENetMultiplayerPeer.new()
+        var error = peer.create_client(server_ip, server_port)
+        if error == OK:
+                multiplayer.multiplayer_peer = peer
+                partner_id = 0
+                AudioManager.clear_partner_id()
+                _audio_initialized = false
+                showStatus("Attempting connection to %s server at %s:%d..." % [conn_type, server_ip, server_port])
+        else:
+                showStatus("Failed to create client peer: %s" % error)
 
 func _process(delta):
-	if serverIsReady:
-		peer.poll()
-	pass
+        if serverIsReady:
+                peer.poll()
+        pass
 
 func peerConnected(id):
 	print("peer connected! " + str(id))
@@ -61,7 +62,31 @@ func peerDisconnected(id):
 		AudioManager.clear_partner_id()
 		
 func _on_connect_to_server_pressed():
-	connect_client_to_server()
+        connect_client_to_server()
 
 func showStatus(_str: String):
-	$"../Status".text = _str
+        $"../Status".text = _str
+
+func _on_connected_to_server():
+        var unique_id := multiplayer.get_unique_id()
+        partner_id = 0
+        AudioManager.clear_partner_id()
+        if !_audio_initialized:
+                AudioManager.setupAudio(unique_id)
+                _audio_initialized = true
+
+        if _connecting_to_local:
+                showStatus("You're connected to the local app, id = " + str(unique_id))
+        else:
+                showStatus("Connected to the remote server, id = " + str(unique_id))
+
+func _on_connection_failed():
+        showStatus("Failed to connect to server.")
+        partner_id = 0
+        AudioManager.clear_partner_id()
+
+func _on_server_disconnected():
+        showStatus("Disconnected from server.")
+        partner_id = 0
+        AudioManager.clear_partner_id()
+        _audio_initialized = false

--- a/Server.gd
+++ b/Server.gd
@@ -4,8 +4,9 @@ extends Node
 var peer = ENetMultiplayerPeer.new()
 var serverIsReady : bool
 var partner_id : int = 0
-var port_local = 8910
-var port_remote = 4242
+const DEFAULT_PORT := 4242
+var port_local := DEFAULT_PORT
+var port_remote := DEFAULT_PORT
 
 func _ready():
 	if OS.has_feature("dedicated_server"):


### PR DESCRIPTION
## Summary
- ensure local and remote servers listen on the same default port so LAN clients can connect
- defer audio initialization for clients until the ENet connection is established and reuse it for remote connections
- improve status handling for client connection lifecycle events

## Testing
- not run (Godot project)


------
https://chatgpt.com/codex/tasks/task_e_68d18ad3de388331936170c12d342c6b