### PR TITLE
Skip audio setup on dedicated server

### DIFF
--- a/audio_manager.gd
+++ b/audio_manager.gd
@@ -23,9 +23,14 @@ func _ready():
 
 
 func setupAudio(id):
-	input = AudioStreamPlayer.new()
-	set_multiplayer_authority(id)
-	if is_multiplayer_authority():
+        if OS.has_feature("dedicated_server"):
+                print("Dedicated server detected; skipping audio setup.")
+                audioIsReady = false
+                return
+
+        input = AudioStreamPlayer.new()
+        set_multiplayer_authority(id)
+        if is_multiplayer_authority():
 		input.stream = AudioStreamMicrophone.new()
 		input.name = "NewInput"
 		var microphone_bus_name := "MicrophoneBus"


### PR DESCRIPTION
## Summary
- skip audio initialization when running on a dedicated server build

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1ae463e3483318514b0b142ac2ef8